### PR TITLE
Update docker to show live changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ RUN         pip install \
               psycopg2 \
               streamlit
 
-COPY        . ./
+#For live development mount the application source in the container rather than copying it in
+#COPY        . ./

--- a/Dockerfile-live
+++ b/Dockerfile-live
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S docker image build -t ia2fil . -f
+#!/usr/bin/env -S docker image build -t fil-onboarding-report . -f
 
 FROM        python:3
 
@@ -14,4 +14,5 @@ RUN         pip install \
               psycopg2 \
               streamlit
 
-COPY        . ./
+#For live development mount the application source in the container rather than copying it in
+#COPY        . ./

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ docker compose up -d
 There is a special version of the docker container intended for live updates and development
 
 ```
-$ docker image build -t fil-onboarding-report -f Dockerfile .
+$ docker image build -t fil-onboarding-report -f Dockerfile-live .
 
 $ docker container run --rm -it -p 8501:8501 --env-file=.env -v "$(pwd):/app" fil-onboarding-report
 ```

--- a/README.md
+++ b/README.md
@@ -22,4 +22,27 @@ Alternatively, use Docker Compose:
 $ docker compose up -d
 ```
 
+#For Live Development
+There is a special version of the docker container intended for live updates and development
+
+```
+$ docker image build -t fil-onboarding-report -f Dockerfile .
+
+$ docker container run --rm -it -p 8501:8501 --env-file=.env -v "$(pwd):/app" fil-onboarding-report
+```
+
+Also for live development to work, a new folder called `.streamlit` needs to be added with `config.toml` inside it. In `config.toml` this code needs to be added:
+
+```
+# this is needed for local development with docker
+[server]
+# if you don't want to start the default browser:
+headless = true
+# you will need this for local development:
+runOnSave = true
+
+# If running docker on windows host:
+# fileWatcherType = "poll"
+```
+
 Access http://localhost:8501/ in a web browser for interactive insights.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   filecoin:
-    image: ia2fil
+    image: fil-onboarding-report
     build: ./
     env_file: .env
     networks:


### PR DESCRIPTION
This pr updates the Dockerfile to allow live updates showing when the container gets built. Docker would reference the /app directory and show changes when a file is saved. It wasn't showing updates instantly before because it was copying the workspace to the docker container instead of referencing it. 


Also a new folder called `.streamlit` needs to be added with `config.toml` inside it. In  `config.toml` this code needs to be added: 

```
# this is needed for local development with docker
[server]
# if you don't want to start the default browser:
headless = true
# you will need this for local development:
runOnSave = true

# If running docker on windows host:
# fileWatcherType = "poll"
```